### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-package-and-push.yml
+++ b/.github/workflows/helm-package-and-push.yml
@@ -57,6 +57,8 @@ jobs:
   deploy:
     needs: package-and-push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       BACKEND_HELM_CHART_VERSION: "${{ needs.package-and-push.outputs.BACKEND_HELM_CHART_VERSION }}"


### PR DESCRIPTION
Potential fix for [https://github.com/andrislapins/cv_web/security/code-scanning/2](https://github.com/andrislapins/cv_web/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `deploy` job. Based on the steps in the job, the minimal required permissions are likely `contents: read`, as the job interacts with repository contents and uses a GitHub App token for other operations. This change will ensure that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of unintended access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
